### PR TITLE
Fixed safari bug... see details!

### DIFF
--- a/app/scripts/controllers/softpen.js
+++ b/app/scripts/controllers/softpen.js
@@ -25,9 +25,9 @@ var loadFabric = function() {
 
   $(document).ready(function() {
     var buttons = $(".color-button");
-    for (var i = 0; i < buttons.length; i++) {
-      buttons[i].style = "color: " + colors[buttons[i].value];
-    }
+    buttons.each(function(index) {
+      $(this).css("color", colors[buttons[index].value]);
+    });
   });
 
 


### PR DESCRIPTION
Safari doesn't like if you set attributes on DOM elements! If you get an error about assigning to a readonly attribute on safari, make sure you're not settings properties directly on a DOM element! This bug was

``` js
var elements = $('.some-class');
for (var i = 0 ; ...) {
    // elements[i] is a raw DOM element! Don't assign to it!!!
    elements[i].style = ...; // no!

    // instead, use
    elements.each(function(index) {
        $(this).css(...);
    });
}
```

BUG!
